### PR TITLE
Fix homepage typo

### DIFF
--- a/src/components/sidebar/links/Links.jsx
+++ b/src/components/sidebar/links/Links.jsx
@@ -26,7 +26,7 @@ const itemVariants = {
 };
 
 const Links = () => {
-  const items = ["Homapage", "Services", "Portfolio", "Contact", "About"];
+  const items = ["Homepage", "Services", "Portfolio", "Contact", "About"];
   return (
     <motion.div className="links" variants={variants}>
       {items.map((item) => (


### PR DESCRIPTION
## Summary
- correct a minor typo in sidebar links

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6841722254088325944ce8573fe96fb5